### PR TITLE
Use scopes instead of environment variables.

### DIFF
--- a/Commands/Ensure Trailing Newline.tmCommand
+++ b/Commands/Ensure Trailing Newline.tmCommand
@@ -11,13 +11,19 @@ Linter.ensure_trailing_newline!
 </string>
 	<key>input</key>
 	<string>document</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>name</key>
 	<string>Ensure Trailing Newline</string>
 	<key>outputCaret</key>
 	<string>interpolateByLine</string>
+	<key>outputFormat</key>
+	<string>text</string>
 	<key>outputLocation</key>
 	<string>discard</string>
 	<key>uuid</key>
 	<string>B6CC0FDC-0705-4435-AAFA-BC45A8E9A0E7</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Commands/LintStripEnsure on Save.tmCommand
+++ b/Commands/LintStripEnsure on Save.tmCommand
@@ -22,6 +22,8 @@ Linter.lint_strip_ensure_on_save</string>
 	<string>html</string>
 	<key>outputLocation</key>
 	<string>newWindow</string>
+	<key>scope</key>
+	<string>attr.linter.lint-on-save, attr.linter.strip-whitespace-on-save, attr.linter.ensure_newline_on_save</string>
 	<key>uuid</key>
 	<string>483D338D-EC9F-4777-92C0-DFCBE02BD3A0</string>
 	<key>version</key>

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Provides Linting functionality to TextMate to make it easier to write better qua
 - Linting on request of Bash, JSON, Markdown and Ruby files
 - Strips trailing whitespace on request from the end of lines (except after Ruby `__END__` blocks)
 - Adds trailing newlines on request to the end of files missing them
-- If set in `.tm_properties` or the environment:
-  - `LINTER_LINT_ON_SAVE` automatically runs Linter on save for supported file types
-  - `LINTER_STRIP_WHITESPACE_ON_SAVE` automatically strips trailing whitespace on save
-  - `LINTER_ENSURE_NEWLINE_ON_SAVE` automatically adds a training newline on save
-  - `LINTER_FIX_ON_SAVE` automatically fixes lints if possible (e.g. with RuboCop).
+- If set in `.tm_properties`'s [`scopeProperties`](https://gist.github.com/dvessel/1478685#other) (space separated, set either globally or for a given language like `[ source.ruby ]`):
+  - `attr.linter.lint-on-save` automatically runs Linter on save for supported file types
+  - `attr.linter.strip-whitespace-on-save` automatically strips trailing whitespace on save
+  - `attr.linter.ensure-newline-on-save` automatically adds a training newline on save
+  - `attr.linter.fix-on-save` automatically fixes lints if possible (e.g. with RuboCop).
 
 ## Installation
 

--- a/Support/lib/linter.rb
+++ b/Support/lib/linter.rb
@@ -5,8 +5,17 @@ $LOAD_PATH << "#{ENV["TM_BUNDLE_SUPPORT"]}/lib"
 module Linter
   module_function
 
+  def tm_scope
+    ENV["TM_SCOPE"].to_s
+  end
+
+  def tm_scopes
+    tm_scope.split(" ")
+  end
+
+
   def setting?(key)
-    ENV["LINTER_#{key.to_s.upcase}"].to_s == "true"
+    tm_scopes.include?("attr.linter.#{key.to_s.gsub("_", "-")}")
   end
 
   def strip_trailing_whitespace!(write: true)
@@ -57,7 +66,6 @@ module Linter
   def lint(manually_requested: true)
     return if filepath.empty?
 
-    tm_scope = ENV["TM_SCOPE"].to_s
     language_found = false
     language_selectors = {
       bash: { select: /source\.shell/ },
@@ -80,7 +88,7 @@ module Linter
     return if language_found
     return unless manually_requested
 
-    first_scope = tm_scope.split(" ").first
+    first_scope = tm_scopes.first
     puts "Error: no Linter found for #{first_scope}! Please consider submitting a pull request to https://github.com/MikeMcQuaid/Linter.tmbundle to add one."
   end
 


### PR DESCRIPTION
This is an experiment to let this be integrated into TextMate as an installable plugin.

CC @infininight for thoughts
  